### PR TITLE
Patched kibana configs to support ssl

### DIFF
--- a/images/logstash14/Dockerfile
+++ b/images/logstash14/Dockerfile
@@ -18,6 +18,9 @@ RUN \
 ADD etc/supervisor/conf.d/elasticsearch.conf /etc/supervisor/conf.d/elasticsearch.conf
 ADD etc/supervisor/conf.d/logstash.conf /etc/supervisor/conf.d/logstash.conf
 
+ADD etc/logstash/logstash.conf /etc/logstash/logstash.conf
+ADD etc/kibana/config.js /opt/logstash/vendor/kibana/config.js
+
 ADD scripts /scripts
 RUN chmod +x /scripts/*.sh
 
@@ -29,5 +32,3 @@ EXPOSE 9200
 EXPOSE 9300
 
 VOLUME ["/data"]
-
-ADD etc/logstash/logstash.conf /etc/logstash/logstash.conf

--- a/images/logstash14/etc/kibana/config.js
+++ b/images/logstash14/etc/kibana/config.js
@@ -1,0 +1,26 @@
+define(['settings'],
+function (Settings) {
+  "use strict";
+  return new Settings({
+    elasticsearch: window.location.protocol+"//"+window.location.hostname+":"+window.location.port,
+    default_route: '/dashboard/file/default.json',
+    kibana_index: "kibana-int",
+    panel_names: [
+      'histogram',
+      'map',
+      'goal',
+      'table',
+      'filtering',
+      'timepicker',
+      'text',
+      'hits',
+      'column',
+      'trends',
+      'bettermap',
+      'query',
+      'terms',
+      'stats',
+      'sparklines'
+    ]
+  });
+});

--- a/images/logstash15/Dockerfile
+++ b/images/logstash15/Dockerfile
@@ -18,6 +18,10 @@ RUN \
 ADD etc/supervisor/conf.d/elasticsearch.conf /etc/supervisor/conf.d/elasticsearch.conf
 ADD etc/supervisor/conf.d/logstash.conf /etc/supervisor/conf.d/logstash.conf
 
+ADD etc/logstash/logstash.conf /etc/logstash/logstash.conf
+ADD etc/kibana/config.js /opt/logstash/vendor/kibana/config.js
+
+
 ADD scripts /scripts
 RUN chmod +x /scripts/*.sh
 
@@ -29,5 +33,3 @@ EXPOSE 9200
 EXPOSE 9300
 
 VOLUME ["/data"]
-
-ADD etc/logstash/logstash.conf /etc/logstash/logstash.conf

--- a/images/logstash15/etc/kibana/config.js
+++ b/images/logstash15/etc/kibana/config.js
@@ -1,0 +1,26 @@
+define(['settings'],
+function (Settings) {
+  "use strict";
+  return new Settings({
+    elasticsearch: window.location.protocol+"//"+window.location.hostname+":"+window.location.port,
+    default_route: '/dashboard/file/default.json',
+    kibana_index: "kibana-int",
+    panel_names: [
+      'histogram',
+      'map',
+      'goal',
+      'table',
+      'filtering',
+      'timepicker',
+      'text',
+      'hits',
+      'column',
+      'trends',
+      'bettermap',
+      'query',
+      'terms',
+      'stats',
+      'sparklines'
+    ]
+  });
+});


### PR DESCRIPTION
Previously kibana configs forced http:// for
the API calls it makes, which cause lots of angry browser
errors when using SSL. This patch allows it to use the
protocol that was used when requesting the page, for greater
fixiness.

This is a blatant rip off from James Hunt (@filefrog)'s commit
on Long Nguyen's logstash docker image repo.
