### PR TITLE
Added/enabled the elasticsearch-cloud-aws plugin.

### DIFF
--- a/images/logstash14/Dockerfile
+++ b/images/logstash14/Dockerfile
@@ -24,6 +24,8 @@ ADD etc/kibana/config.js /opt/logstash/vendor/kibana/config.js
 ADD scripts /scripts
 RUN chmod +x /scripts/*.sh
 
+RUN /usr/share/elasticsearch/bin/plugin install elasticsearch/elasticsearch-cloud-aws/2.4.2
+
 ENTRYPOINT ["/scripts/run.sh"]
 CMD [""]
 

--- a/images/logstash15/Dockerfile
+++ b/images/logstash15/Dockerfile
@@ -25,6 +25,8 @@ ADD etc/kibana/config.js /opt/logstash/vendor/kibana/config.js
 ADD scripts /scripts
 RUN chmod +x /scripts/*.sh
 
+RUN /usr/share/elasticsearch/bin/plugin install elasticsearch/elasticsearch-cloud-aws/2.4.2
+
 ENTRYPOINT ["/scripts/run.sh"]
 CMD [""]
 


### PR DESCRIPTION
This allows logstash images to snapshot themselves up to AWS/S3,
when requested via the snapshot API.
